### PR TITLE
Add creation date of each item to feed output

### DIFF
--- a/feed/domain.py
+++ b/feed/domain.py
@@ -2,6 +2,7 @@
 
 from typing import List, Optional
 from dataclasses import dataclass
+from datetime import datetime
 
 from feed.consts import UpdateActions
 
@@ -22,9 +23,10 @@ class Document:
 
     arxiv_id: str
     version: int
-    doi:Optional[str]
+    doi: Optional[str]
     title: str
     abstract: str
+    created: Optional[datetime]
     authors: List[Author]
     categories: List[str]
     license: str

--- a/feed/fetch_data.py
+++ b/feed/fetch_data.py
@@ -177,11 +177,12 @@ def create_document(record:Tuple[UpdateActions, Metadata])->Document:
 
     categories = metadata.abs_categories.split(" ") if metadata.abs_categories else []
 
-    return Document(    
+    return Document(
         arxiv_id=metadata.paper_id,
         version=metadata.version,
         title=metadata.title if metadata.title else "",
         abstract=metadata.abstract if metadata.abstract else "",
+        created=metadata.created,
         authors=authors,
         categories=categories,
         license=metadata.license if metadata.license else "",

--- a/feed/serializers/serializer.py
+++ b/feed/serializers/serializer.py
@@ -1,4 +1,5 @@
 from typing import Union
+from datetime import UTC
 
 from flask import current_app, url_for
 from feedgen.feed import FeedGenerator
@@ -120,6 +121,8 @@ class Serializer:
             entry.arxiv.journal_ref(document.journal_ref.strip())
         if document.doi:
             entry.arxiv.doi(document.doi)
+        if document.created:
+            entry.published(document.created.replace(tzinfo=UTC))
 
         entry.link(
             {

--- a/feed/tests/conftest.py
+++ b/feed/tests/conftest.py
@@ -75,11 +75,12 @@ def sample_author2():
 
 @pytest.fixture
 def sample_doc(sample_author):
-    return Document(    
+    return Document(
         arxiv_id="1234.5678",
         version=3,
         title="Mysteries of the Universe",
         abstract="This whole concept is abstract.",
+        created=datetime(2019, 10, 10, 0, 0, 0),
         authors=[sample_author],
         categories=["astro-ph","math.NT"],
         license="http://creativecommons.org/licenses/by/4.0/",
@@ -90,11 +91,12 @@ def sample_doc(sample_author):
 
 @pytest.fixture
 def sample_doc_jref(sample_author):
-    return Document(    
+    return Document(
         arxiv_id="1234.5678",
         version=3,
         title="Mysteries of the Universe",
         abstract="This whole concept is abstract.",
+        created=datetime(2019, 10, 10, 0, 0, 0),
         authors=[sample_author],
         categories=["astro-ph","math.NT"],
         license="http://creativecommons.org/licenses/by/4.0/",


### PR DESCRIPTION
This assumes that the database stores datetimes in UTC. Additionally, the RSS/Atom documentation would need to be updated as well with the new fields.

Fixes #27